### PR TITLE
Update CSP to include content from minimum resources

### DIFF
--- a/src/features/previewContentProvider.ts
+++ b/src/features/previewContentProvider.ts
@@ -16,7 +16,8 @@ export class SvgContentProvider implements vscode.TextDocumentContentProvider {
     private getHtml(document: vscode.TextDocument, resource: vscode.Uri) {
         const base = `<base href="${this.getBaseUrl()}">`;
         const securityPolicy = `
-            <meta http-equiv="Content-Security-Policy" content="default-src 'self' vscode-resource: data:">
+            <meta http-equiv="Content-Security-Policy" 
+                content="default-src 'none'; script-src vscode-resource:; img-src data: vscode-resource:; style-src vscode-resource:;">
         `;
         const css = `<link rel="stylesheet" type="text/css" href="vscode-resource:styles.css">`;
         const scripts = `<script type="text/javascript" src="vscode-resource:index.js"></script>`;


### PR DESCRIPTION
Hi!

Your plugin was mentioned in https://github.com/microsoft/vscode/issues/79340 as one of the extensions lacking content-security-policy in its webview. While I found that you did use one, your policy was not as restrictive as possible.

I have removed the `self` property as it was not needed. Your extension uses only script, style and images resources, so using the `default-src` included too many resources like fonts, iframes, media and many more (See in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#No_inheritance_with_default-src)). 

I have tested the new policy in the Webview Developer Tools and it works!