### PR TITLE
Fix when clauses for commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,14 @@
     ],
     "activationEvents": [
         "onLanguage:xml",
+        "onLanguage:svg",
         "onWebviewPanel:svg-preview",
-        "onCustomEditor:svgPreviewer.customEditor"
+        "onCustomEditor:svgPreviewer.customEditor",
+        "onCommand:vscode.openWith",
+        "onCommand:svg.showPreview",
+        "onCommand:svg.showPreviewToSide",
+        "onCommand:svg.showSource",
+        "workspaceContains:**/*.svg"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
             "editor/title": [
                 {
                     "command": "svg.showPreviewToSide",
-                    "when": "editorLangId == xml",
+                    "when": "resourceExtname == .svg",
                     "alt": "svg.showPreviewToSide",
                     "group": "navigation"
                 },
@@ -74,12 +74,12 @@
             "commandPalette": [
                 {
                     "command": "svg.showPreview",
-                    "when": "editorLangId == xml",
+                    "when": "resourceExtname == .svg",
                     "group": "navigation"
                 },
                 {
                     "command": "svg.showPreviewToSide",
-                    "when": "editorLangId == xml",
+                    "when": "resourceExtname == .svg",
                     "group": "navigation"
                 },
                 {
@@ -92,7 +92,7 @@
                 {
                     "command": "svg.showPreview",
                     "group": "navigation",
-                    "when": "resourceLangId == xml"
+                    "when": "resourceExtname == .svg"
                 }
             ]
         },
@@ -122,13 +122,13 @@
                 "command": "svg.showPreview",
                 "key": "shift+ctrl+v",
                 "mac": "shift+cmd+v",
-                "when": "editorLangId == xml"
+                "when": "resourceExtname == .svg"
             },
             {
                 "command": "svg.showPreviewToSide",
                 "key": "ctrl+k v",
                 "mac": "cmd+k v",
-                "when": "editorLangId == xml"
+                "when": "resourceExtname == .svg"
             }
         ]
     },


### PR DESCRIPTION
Always use `resourceExtname` of `.svg` to get it working in both the Explorer and editor contexts.